### PR TITLE
New Feature: Featured image

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -148,6 +148,7 @@ class modJoomImagesHelper extends joominterface
     $this->addConfig('includesubcats', $params->get('includesubcats', 0));
     $this->addConfig('dynamiccats', $params->get('dynamiccats', 0));
     $this->addConfig('showhidden', $params->get('showhidden', 0));
+    $this->addConfig('showfeatured', $params->get('showfeatured', 0));
     if(is_numeric($params->get('votesctsel')) && $params->get('votesctsel') >= 0)
     {
       $this->addConfig('votesctsel', $params->get('votesctsel', -1));
@@ -479,6 +480,12 @@ class modJoomImagesHelper extends joominterface
       $query->where('c.hidden    = 0');
       $query->where('c.in_hidden = 0');
       $query->where('p.hidden    = 0');
+    }
+
+    // Show only featured images
+    if($this->getConfig('showfeatured'))
+    {
+      $query->where('p.featured  = 1');
     }
 
     // Show only images with votes = x

--- a/language/de-DE/de-DE.mod_joomimg.ini
+++ b/language/de-DE/de-DE.mod_joomimg.ini
@@ -265,3 +265,10 @@ JIOPENINBOXLINK_THICKBOX3="Thickbox3"
 JIOPENINBOXLINK_SLIMBOX="Slimbox"
 JIDOWNLOADS="Downloads"
 JIDOWNLOADSSHOW="Soll die Anzahl der Downloads angezeigt werden?"
+;
+;------------------------------------------------------------------------------------
+; Neue oder geänderte Konstanten seit JoomImages 3.3.0
+;------------------------------------------------------------------------------------
+; Neu
+JISHWFEATURED="Nur wichtige Bilder"
+JISHWFEATUREDDESC="Zeigt nur Bilder an, die als 'wichtig' gekennzeichnet sind"

--- a/language/de-DE/de-DE.mod_joomimg.ini
+++ b/language/de-DE/de-DE.mod_joomimg.ini
@@ -270,5 +270,5 @@ JIDOWNLOADSSHOW="Soll die Anzahl der Downloads angezeigt werden?"
 ; Neue oder geänderte Konstanten seit JoomImages 3.3.0
 ;------------------------------------------------------------------------------------
 ; Neu
-JISHWFEATURED="Nur wichtige Bilder"
-JISHWFEATUREDDESC="Zeigt nur Bilder an, die als 'wichtig' gekennzeichnet sind"
+JISHWFEATURED="Nur 'Featured' Bilder"
+JISHWFEATUREDDESC="Zeigt nur Bilder die als 'Featured' markiert worden sind"

--- a/language/en-GB/en-GB.mod_joomimg.ini
+++ b/language/en-GB/en-GB.mod_joomimg.ini
@@ -267,3 +267,10 @@ JIOPENINBOXLINK_THICKBOX3="Thickbox3"
 JIOPENINBOXLINK_SLIMBOX="Slimbox"
 JIDOWNLOADS="Downloads"
 JIDOWNLOADSSHOW="Show the number of downloads?"
+;
+;------------------------------------------------------------------------------------
+; New or changed constants since JoomImages 3.3.0
+;------------------------------------------------------------------------------------
+; New
+JISHWFEATURED="Featured images only"
+JISHWFEATUREDDESC="Show only images marked as featured"

--- a/mod_joomimg.php
+++ b/mod_joomimg.php
@@ -42,9 +42,9 @@ $moduleid = $module->id;
 // Create helper object
 $joomimgObj = new modJoomImagesHelper();
 
-if($joomimgObj->getGalleryVersion() < "3.0")
+if($joomimgObj->getGalleryVersion() < "3.3")
 {
-  echo JText::sprintf('JIJOOMGALLERY_NOT_UPTODATE', '3.0');
+  echo JText::sprintf('JIJOOMGALLERY_NOT_UPTODATE', '3.3');
   return;
 }
 

--- a/mod_joomimg.xml
+++ b/mod_joomimg.xml
@@ -108,6 +108,10 @@
         <option value="0">JINO</option>
         <option value="1">JIYES</option>
       </field>    
+      <field class="btn-group" name="showfeatured" type="radio" default="0" label="JISHWFEATURED" description="JISHWFEATUREDDESC">
+        <option value="0">JINO</option>
+        <option value="1">JIYES</option>
+      </field>  
       <field name="votesctsel" type="text" default="" label="JIVOTESCTSEL" description="JIVOTESCTSELDESCR" />
     </fieldset>
     <fieldset name="JIGROUPDEFAULTVIEW">


### PR DESCRIPTION
Umsetzung dieses Feature-Requests: http://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/2787336-featured-images
Damit ist es möglich, nur die als "Wichtig" markierten Bilder in JoomImages anzuzeigen.
Vorher ist die Übernahme dieses Pull requests für die JoomGallery notwendig: https://github.com/JoomGallery/JoomGallery/pull/77
