### PR TITLE
Add support for alternative layouts

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -284,6 +284,8 @@ class modJoomImagesHelper extends joominterface
     $this->addConfig('borderstyle', $params->get('borderstyle', 'solid'));
     $this->addConfig('bordercolor', $params->get('bordercolor', '#000'));
     $this->addConfig('borderpadding', $params->get('borderpadding', '2px'));
+
+    $this->addConfig('alternativeLayout', $params->get('alternativeLayout', 'default'));
   }
 
   /**

--- a/mod_joomimg.php
+++ b/mod_joomimg.php
@@ -58,7 +58,7 @@ if($joomimgObj->getConfig('slideshowthis') == 1)
 }
 else
 {
-  $path = JModuleHelper::getLayoutPath('mod_joomimg', 'default');
+  $path = JModuleHelper::getLayoutPath('mod_joomimg', $joomimgObj->getConfig('alternativeLayout'));
 }
 if(JFile::exists($path))
 {

--- a/mod_joomimg.xml
+++ b/mod_joomimg.xml
@@ -354,6 +354,9 @@
         <option value="elastic:in:out">Elastic.easeInOut</option>
         </field>
       </fieldset>
+	  <fieldset name="advanced">
+          <field name="alternativeLayout" type="modulelayout" label="JFIELD_ALT_LAYOUT_LABEL" description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
+      </fieldset>
     </fields>
   </config>
 </extension>


### PR DESCRIPTION
I made this as simple as possible. 

One thing that could lead to confusion is the `slideshowthis` configuration option. If it's activated the `alternativeLayout` option is ignored.  To solve this you could put the `alternativeLayout` option on the general configuration tab for selecting the layout and remove the `slideshowthis` option completely. But this would break existing installations. Therefore I've put this options under the advanced tab. 
